### PR TITLE
Expose Freeform ICP as pub, Remove Rotation Generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ via the [tracing](https://github.com/tokio-rs/tracing) crate.
 
 To use it, simply enable the `tracing` feature in your Cargo.toml, 
 and use your choice of a subscriber.
+Note that different functions have different `tracing::Level`s.
+
+Since each and every function is instrumented, be sure to remember the overhead for enabling tracing.
 
 ## pregenerated
 This crate heavily relies on generics, and therefore suffers performance penalties in `debug`, (but is _very_ fast in `release`).
@@ -64,7 +67,7 @@ Code example:
 let res = icp::icp::<f32, 2>(...);
 
 // Do this(Runs much faster):
-let res = icp::f32::icp_2d(...);
+let res = icp::single_precision::icp_2d(...);
 ```
 
 The `pregenerated` macro is enabled by default.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ opt-level = 3
 Code example:
 ```rust
 // Instead of doing this:
-let res = icp::icp::<f32, 2, Const<2>>(...);
+let res = icp::icp::<f32, 2>(...);
 
 // Do this(Runs much faster):
 let res = icp::f32::icp_2d(...);

--- a/crates/algorithms/examples/visualized_icp_2d.rs
+++ b/crates/algorithms/examples/visualized_icp_2d.rs
@@ -84,7 +84,7 @@ impl eframe::App for VisualizerApp {
                 log::info!("Running iteration");
 
                 self.current_iteration += 1;
-                match icp_iteration::<_, UnitComplex<_>, 2>(
+                match icp_iteration::<_, 2>(
                     &self.points_a,
                     &mut self.transformed_points,
                     &self.points_b,

--- a/crates/algorithms/examples/visualized_icp_2d.rs
+++ b/crates/algorithms/examples/visualized_icp_2d.rs
@@ -49,7 +49,7 @@ struct VisualizerApp {
 
 impl VisualizerApp {
     fn new(config: RunConfiguration) -> Self {
-        let points_a = generate_point_cloud(config.num_points, -1.0..=1.0);
+        let points_a = generate_point_cloud(config.num_points, std::array::from_fn(|_| -1.0..=1.0));
         let points_b = transform_point_cloud(
             &points_a,
             Isometry2::from_parts(

--- a/crates/algorithms/src/bresenham/mod.rs
+++ b/crates/algorithms/src/bresenham/mod.rs
@@ -78,9 +78,9 @@ where
 
 #[cfg(feature = "pregenerated")]
 macro_rules! impl_bresenham_algorithm {
-    ($precision:expr, $nd:expr, $out:expr) => {
+    ($precision:expr, doc $doc:tt, $nd:expr, $out:expr) => {
         ::paste::paste! {
-            #[doc = "Bresenham line drawing algorithm in " $nd "D space."]
+            #[doc = "Bresenham line drawing algorithm, with " $doc "-precision, in " $nd "D space."]
             #[doc = "# Arguments"]
             #[doc = "* `start_point`: A [`Point<" $precision ", " $nd ">`](nalgebra::Point), representing the starting point of the line."]
             #[doc = "* `end_point`: A [`Point<" $precision ", " $nd ">`](nalgebra::Point), representing the ending point of the line."]
@@ -89,30 +89,31 @@ macro_rules! impl_bresenham_algorithm {
             #[doc = "A [`Vec`] of [`Point<" $precision ", " $out ">`](nalgebra::Point)s, representing the drawn line, including the starting point and ending point."]
             #[doc = ""]
             #[doc = "NOTE: The returned [`Vec`] will always go from the starting point to the ending point, regardless of direction in axis."]
-            pub fn [<plot_bresenham_line_$nd d_returns_$out>](start_point: nalgebra::Point<$precision, $nd>, end_point: nalgebra::Point<$precision, $nd>) -> crate::Vec<nalgebra::Point<$out, $nd>> {
+            pub fn [<plot_$nd d_$out _bresenham_line>](start_point: nalgebra::Point<$precision, $nd>, end_point: nalgebra::Point<$precision, $nd>) -> crate::Vec<nalgebra::Point<$out, $nd>> {
                     super::plot_bresenham_line::<$precision, $out, $nd>(start_point, end_point)
             }
         }
     };
 
-    ($prec:expr, $nd:expr) => {
-        impl_bresenham_algorithm!($prec, $nd, i32);
-        impl_bresenham_algorithm!($prec, $nd, i64);
-        impl_bresenham_algorithm!($prec, $nd, isize);
+    ($prec:expr, doc $doc:tt, $nd:expr) => {
+        impl_bresenham_algorithm!($prec, doc $doc, $nd, i32);
+        impl_bresenham_algorithm!($prec, doc $doc, $nd, i64);
+        impl_bresenham_algorithm!($prec, doc $doc, $nd, isize);
 
-        impl_bresenham_algorithm!($prec, $nd, u32);
-        impl_bresenham_algorithm!($prec, $nd, u64);
-        impl_bresenham_algorithm!($prec, $nd, usize);
+        impl_bresenham_algorithm!($prec, doc $doc, $nd, u32);
+        impl_bresenham_algorithm!($prec, doc $doc, $nd, u64);
+        impl_bresenham_algorithm!($prec, doc $doc, $nd, usize);
 
-        impl_bresenham_algorithm!($prec, $nd, $prec);
+        impl_bresenham_algorithm!($prec, doc $doc, $nd, f32);
+        impl_bresenham_algorithm!($prec, doc $doc, $nd, f64);
     };
 
     ($prec:expr, doc $doc:tt) => {
         ::paste::paste! {
             #[doc = "A " $doc "-precision implementation of a bresenham line-drawing algorithm."]
-            pub mod $prec {
-                impl_bresenham_algorithm!($prec, 2);
-                impl_bresenham_algorithm!($prec, 3);
+            pub mod [<$doc _precision>] {
+                impl_bresenham_algorithm!($prec, doc $doc, 2);
+                impl_bresenham_algorithm!($prec, doc $doc, 3);
             }
         }
     }
@@ -130,7 +131,7 @@ mod tests {
 
     #[test]
     fn test_plot_bresenham_line_2d_nonsteep_pos() {
-        let res = f32::plot_bresenham_line_2d_returns_isize(
+        let res = single_precision::plot_2d_isize_bresenham_line(
             Point2::new(0.0f32, 0.0f32),
             Point2::new(10.0f32, 3.0f32),
         );
@@ -154,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_plot_bresenham_line_2d_steep_pos() {
-        let res = f32::plot_bresenham_line_2d_returns_isize(
+        let res = single_precision::plot_2d_isize_bresenham_line(
             Point2::new(0.0f32, 0.0f32),
             Point2::new(3.0f32, 10.0f32),
         );
@@ -178,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_plot_bresenham_line_2d_nonsteep_neg() {
-        let res = f32::plot_bresenham_line_2d_returns_isize(
+        let res = single_precision::plot_2d_isize_bresenham_line(
             Point2::new(0.0f32, 0.0f32),
             Point2::new(-10.0f32, -3.0f32),
         );
@@ -202,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_plot_bresenham_line_2d_steep_neg() {
-        let res = f32::plot_bresenham_line_2d_returns_isize(
+        let res = single_precision::plot_2d_isize_bresenham_line(
             Point2::new(0.0f32, 0.0f32),
             Point2::new(-3.0f32, -10.0f32),
         );
@@ -226,7 +227,7 @@ mod tests {
 
     #[test]
     fn test_plot_bresenham_line_3d_x() {
-        let res = f32::plot_bresenham_line_3d_returns_isize(
+        let res = single_precision::plot_3d_isize_bresenham_line(
             Point3::new(0.0f32, 0.0f32, 0.0f32),
             Point3::new(-3.0f32, -10.0f32, 7.0f32),
         );

--- a/crates/algorithms/src/bresenham/mod.rs
+++ b/crates/algorithms/src/bresenham/mod.rs
@@ -1,6 +1,6 @@
 use crate::{array, Vec};
-use nalgebra::{ComplexField, Point, Scalar};
-use num_traits::{AsPrimitive, Float};
+use nalgebra::{ComplexField, Point, RealField, Scalar};
+use num_traits::AsPrimitive;
 
 /// This is a free-form version of the bresenham line-drawing algorithm,
 /// allowing for any input, any output, and N dimensions, under the constraints of the function.
@@ -26,10 +26,12 @@ pub fn plot_bresenham_line<F, T, const N: usize>(
     end_point: Point<F, N>,
 ) -> Vec<Point<T, N>>
 where
-    F: ComplexField + Float + AsPrimitive<usize> + AsPrimitive<T>,
+    F: RealField + AsPrimitive<usize> + AsPrimitive<T>,
+    usize: AsPrimitive<F>,
     T: Scalar + Copy,
 {
-    let deltas: [F; N] = array::from_fn(|idx| <F as Float>::abs(end_point[idx] - start_point[idx]));
+    let deltas: [F; N] =
+        array::from_fn(|idx| <F as ComplexField>::abs(end_point[idx] - start_point[idx]));
     let steps: [F; N] = array::from_fn(|idx| {
         if end_point[idx] > start_point[idx] {
             F::one()
@@ -49,8 +51,8 @@ where
     let mut points = Vec::with_capacity(<F as AsPrimitive<usize>>::as_(
         deltas[primary_axis] + F::one(),
     ));
-    while <F as Float>::abs(current_point[primary_axis] - end_point[primary_axis])
-        > Float::epsilon()
+    while <F as ComplexField>::abs(current_point[primary_axis] - end_point[primary_axis])
+        > F::default_epsilon()
     {
         points.push(current_point.map(|element| element.as_()));
 
@@ -61,7 +63,7 @@ where
 
             errors[axis] += deltas[axis] / deltas[primary_axis];
 
-            if errors[axis] >= F::one() - (F::one() / F::from_usize(N + 1).unwrap()) {
+            if errors[axis] >= F::one() - (F::one() / (N + 1).as_()) {
                 current_point[axis] += steps[axis];
                 errors[axis] -= F::one();
             }

--- a/crates/algorithms/src/bresenham/mod.rs
+++ b/crates/algorithms/src/bresenham/mod.rs
@@ -82,14 +82,14 @@ macro_rules! impl_bresenham_algorithm {
         ::paste::paste! {
             #[doc = "Bresenham line drawing algorithm, with " $doc "-precision, in " $nd "D space."]
             #[doc = "# Arguments"]
-            #[doc = "* `start_point`: A [`Point<" $precision ", " $nd ">`](nalgebra::Point), representing the starting point of the line."]
-            #[doc = "* `end_point`: A [`Point<" $precision ", " $nd ">`](nalgebra::Point), representing the ending point of the line."]
+            #[doc = "* `start_point`: A [`Point`], representing the starting point of the line."]
+            #[doc = "* `end_point`: A [`Point`], representing the ending point of the line."]
             #[doc = ""]
             #[doc = "# Returns"]
-            #[doc = "A [`Vec`] of [`Point<" $precision ", " $out ">`](nalgebra::Point)s, representing the drawn line, including the starting point and ending point."]
+            #[doc = "A [`Vec`] of [`Point`]s, representing the drawn line, including the starting point and ending point."]
             #[doc = ""]
             #[doc = "NOTE: The returned [`Vec`] will always go from the starting point to the ending point, regardless of direction in axis."]
-            pub fn [<plot_$nd d_$out _bresenham_line>](start_point: nalgebra::Point<$precision, $nd>, end_point: nalgebra::Point<$precision, $nd>) -> crate::Vec<nalgebra::Point<$out, $nd>> {
+            pub fn [<plot_$nd d_$out _bresenham_line>](start_point: Point<$precision, $nd>, end_point: Point<$precision, $nd>) -> Vec<Point<$out, $nd>> {
                     super::plot_bresenham_line::<$precision, $out, $nd>(start_point, end_point)
             }
         }
@@ -112,6 +112,9 @@ macro_rules! impl_bresenham_algorithm {
         ::paste::paste! {
             #[doc = "A " $doc "-precision implementation of a bresenham line-drawing algorithm."]
             pub mod [<$doc _precision>] {
+                use nalgebra::Point;
+                use crate::Vec;
+
                 impl_bresenham_algorithm!($prec, doc $doc, 2);
                 impl_bresenham_algorithm!($prec, doc $doc, 3);
             }

--- a/crates/algorithms/src/haversine/mod.rs
+++ b/crates/algorithms/src/haversine/mod.rs
@@ -71,7 +71,7 @@ where
     feature = "tracing",
     tracing::instrument("Calculate Bearing Between Points", skip_all)
 )]
-pub fn calculate_bearing_on_sphere<T>(point_a: Point2<T>, point_b: Point2<T>) -> T
+pub fn calculate_sphere_bearing<T>(point_a: Point2<T>, point_b: Point2<T>) -> T
 where
     T: Scalar + Float + RealField,
 {
@@ -91,23 +91,21 @@ where
 
 #[cfg(feature = "pregenerated")]
 macro_rules! impl_haversine_formula {
-    ($prec:expr, $prec_str:tt) => {
+    ($prec:expr, doc $doc:tt) => {
         ::paste::paste! {
-            #[doc = "A " $prec_str "-precision implementation of the Haversine formula and adjacent utilities"]
-            pub mod $prec {
-                use super::*;
-
-                #[doc = "Calculates the Haversine distance between two points on a sphere using " $prec_str "-precision floating-point arithmetic."]
+            #[doc = "A " $doc "-precision implementation of the Haversine formula and adjacent utilities"]
+            pub mod [<$doc _precision>] {
+                #[doc = "Calculates the Haversine distance between two points on a sphere using " $doc "-precision floating-point arithmetic."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `point_a`: A [`Point2'] representing the first geographical point."]
-                #[doc = "* `point_b`: A [`Point2`] representing the second geographical point."]
+                #[doc = "* `point_a`: A [`Point2'](nalgebra::Point2) representing the first geographical point."]
+                #[doc = "* `point_b`: A [`Point2`](nalgebra::Point2) representing the second geographical point."]
                 #[doc = "* `sphere_radius`: The radius of the sphere, typically the Earth's radius in kilometers or miles."]
                 #[doc = ""]
                 #[doc = "# Returns"]
                 #[doc = "A '" $prec "', the distance between `point_a` and `point_b` along the surface of the sphere, using the Haversine formula."]
-                pub fn [<calculate_haversine_distance_ $prec>](point_a: nalgebra::Point2<$prec>, point_b: nalgebra::Point2<$prec>, sphere_radius: $prec) -> $prec {
-                    calculate_haversine_distance(point_a,point_b,sphere_radius)
+                pub fn calculate_haversine_distance(point_a: nalgebra::Point2<$prec>, point_b: nalgebra::Point2<$prec>, sphere_radius: $prec) -> $prec {
+                    super::calculate_haversine_distance(point_a,point_b,sphere_radius)
                 }
 
                 #[doc = "Calculates the initial bearing (forward azimuth) from the first point to the second point."]
@@ -118,23 +116,23 @@ macro_rules! impl_haversine_formula {
                 #[doc = "in a clockwise direction."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `point_a`: A [`Point2`] representing the starting geographical point (latitude and longitude)."]
-                #[doc = "* `point_b`: A [`Point2`] representing the destination geographical point (latitude and longitude)."]
+                #[doc = "* `point_a`: A [`Point2`](nalgebra::Point2) representing the starting geographical point (latitude and longitude)."]
+                #[doc = "* `point_b`: A [`Point2`](nalgebra::Point2) representing the destination geographical point (latitude and longitude)."]
                 #[doc = ""]
                 #[doc = "# Returns"]
                 #[doc = "* A value that representing the initial bearing from `point_a` to `point_b`, in radians. The result is normalized"]
                 #[doc = "  to a range of 0 to 2 PI radians."]
-                pub fn [<calculate_bearing_on_sphere_ $prec>](point_a: nalgebra::Point2<$prec>, point_b: nalgebra::Point2<$prec>) -> $prec {
-                    calculate_bearing_on_sphere(point_a,point_b)}
+                pub fn calculate_sphere_bearing(point_a: nalgebra::Point2<$prec>, point_b: nalgebra::Point2<$prec>) -> $prec {
+                    super::calculate_sphere_bearing(point_a,point_b)}
                 }
             }
         }
 }
 
 #[cfg(feature = "pregenerated")]
-impl_haversine_formula!(f32, single);
+impl_haversine_formula!(f32, doc single);
 #[cfg(feature = "pregenerated")]
-impl_haversine_formula!(f64, double);
+impl_haversine_formula!(f64, doc double);
 
 #[cfg(test)]
 mod tests {
@@ -146,7 +144,8 @@ mod tests {
         let point_b = Point2::new(48.8566, 2.3522); // Paris, France
 
         let earth_radius_km = 6371.0;
-        let distance = calculate_haversine_distance(point_a, point_b, earth_radius_km);
+        let distance =
+            double_precision::calculate_haversine_distance(point_a, point_b, earth_radius_km);
         let expected_distance = 877.46; // Approximate distance in km
         assert!(
             (distance - expected_distance).abs() < 0.01,
@@ -157,10 +156,10 @@ mod tests {
 
     #[test]
     fn test_bearing() {
-        let point_a = Point2::new(39.099912, -94.581213); // Kansas City
-        let point_b = Point2::new(38.627089, -90.200203); // St Louis
+        let point_a = Point2::new(39.099_91, -94.581213); // Kansas City
+        let point_b = Point2::new(38.627_09, -90.200_2); // St Louis
 
-        let bearing = calculate_bearing_on_sphere(point_a, point_b);
+        let bearing = single_precision::calculate_sphere_bearing(point_a, point_b);
         let expected_bearing = 96.51; // Approximate bearing in degrees
         assert!(
             (bearing - expected_bearing.to_radians()).abs() < 0.01,

--- a/crates/algorithms/src/icp/helpers.rs
+++ b/crates/algorithms/src/icp/helpers.rs
@@ -22,7 +22,10 @@ use num_traits::{AsPrimitive, NumOps, Zero};
 /// # Returns
 /// A [`T`], representing the sum of all squared distances between each point in `transformed_points_a` and its corresponding point in `points_b`.
 #[inline]
-#[cfg_attr(feature = "tracing", tracing::instrument("Calculate MSE", skip_all))]
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument("Calculate MSE", skip_all, level = "debug")
+)]
 pub(crate) fn calculate_mse<T, const N: usize>(
     transformed_points_a: &[Point<T, N>],
     closest_points_in_b: &[Point<T, N>],
@@ -54,7 +57,7 @@ where
 #[inline]
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument("Calculate Outer Product", skip_all)
+    tracing::instrument("Calculate Outer Product", skip_all, level = "trace")
 )]
 pub(crate) fn outer_product<T, const N: usize>(
     point_a: &Vector<T, Const<N>, ArrayStorage<T, N, 1>>,
@@ -80,7 +83,7 @@ where
 ///
 /// # Returns
 /// A tuple of
-/// * [`SameSizeMat<T, N>`], representing the covariance matrix of the outer products of the centered point clouds.
+/// * [`SameSizeMat`], representing the covariance matrix of the outer products of the centered point clouds.
 /// * [`Point`], representing the `points_a` centeroid.
 /// * [`Point`], representing the `closest_points` centeroid.
 ///
@@ -89,7 +92,7 @@ where
 #[inline]
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument("Estimate Transform And Means", skip_all)
+    tracing::instrument("Estimate Transform And Means", skip_all, level = "debug")
 )]
 pub(crate) fn get_rotation_matrix_and_centeroids<T, const N: usize>(
     transformed_points_a: &[Point<T, N>],

--- a/crates/algorithms/src/icp/mod.rs
+++ b/crates/algorithms/src/icp/mod.rs
@@ -184,7 +184,7 @@ where
 
 #[cfg(feature = "pregenerated")]
 macro_rules! impl_icp_algorithm {
-    ($precision:expr, $nd:expr, $rot_type:expr) => {
+    ($precision:expr, $doc:tt, $nd:expr, $rot_type:expr) => {
         ::paste::paste! {
             #[doc = "An ICP algorithm in " $nd "D space."]
             #[doc = "# Arguments"]
@@ -207,9 +207,9 @@ macro_rules! impl_icp_algorithm {
     ($precision:expr, doc $doc:tt) => {
         ::paste::paste! {
             #[doc = "A " $doc "-precision implementation of a basic ICP algorithm"]
-            pub mod $precision {
-                impl_icp_algorithm!($precision, 2, UnitComplex);
-                impl_icp_algorithm!($precision, 3, UnitQuaternion);
+            pub mod [<$doc _precision>] {
+                impl_icp_algorithm!($precision, $doc, 2, UnitComplex);
+                impl_icp_algorithm!($precision, $doc, 3, UnitQuaternion);
             }
         }
     }
@@ -222,30 +222,28 @@ impl_icp_algorithm!(f64, doc double);
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        icp::types::ICPConfiguration,
-        utils::point_cloud::{generate_point_cloud, transform_point_cloud},
-    };
+    use super::*;
+    use crate::utils::point_cloud::{generate_point_cloud, transform_point_cloud};
 
     #[test]
     fn test_icp_errors() {
         let points = generate_point_cloud(10, -15.0..=15.0);
         let config_builder = ICPConfiguration::builder();
 
-        let res = super::f32::icp_2d(&[], points.as_slice(), config_builder.build());
+        let res = single_precision::icp_2d(&[], points.as_slice(), config_builder.build());
         assert_eq!(res.unwrap_err(), "Source point cloud is empty");
 
-        let res = super::f32::icp_2d(points.as_slice(), &[], config_builder.build());
+        let res = single_precision::icp_2d(points.as_slice(), &[], config_builder.build());
         assert_eq!(res.unwrap_err(), "Target point cloud is empty");
 
-        let res = super::f32::icp_2d(
+        let res = single_precision::icp_2d(
             points.as_slice(),
             points.as_slice(),
             config_builder.with_max_iterations(0).build(),
         );
         assert_eq!(res.unwrap_err(), "Must have more than one iteration");
 
-        let res = super::f32::icp_2d(
+        let res = single_precision::icp_2d(
             points.as_slice(),
             points.as_slice(),
             config_builder.with_mse_interval_threshold(0.0).build(),
@@ -255,7 +253,7 @@ mod tests {
             "MSE interval threshold too low, convergence impossible"
         );
 
-        let res = super::f32::icp_2d(
+        let res = single_precision::icp_2d(
             points.as_slice(),
             points.as_slice(),
             config_builder
@@ -276,7 +274,7 @@ mod tests {
         let isom = nalgebra::Isometry2::new(translation, 0.1);
         let points_transformed = transform_point_cloud(&points, isom);
 
-        let res = super::f32::icp_2d(
+        let res = single_precision::icp_2d(
             points.as_slice(),
             points_transformed.as_slice(),
             ICPConfiguration::builder()
@@ -296,7 +294,7 @@ mod tests {
         let isom = nalgebra::Isometry2::new(translation, 0.1);
         let points_transformed = transform_point_cloud(&points, isom);
 
-        let res = super::f32::icp_2d(
+        let res = single_precision::icp_2d(
             points.as_slice(),
             points_transformed.as_slice(),
             ICPConfiguration::builder()
@@ -314,7 +312,7 @@ mod tests {
         let isom = nalgebra::Isometry2::new(nalgebra::Vector2::new(-0.8, 1.3), 0.1);
         let points_transformed = transform_point_cloud(&points, isom);
 
-        let res = super::f32::icp_2d(
+        let res = single_precision::icp_2d(
             points.as_slice(),
             points_transformed.as_slice(),
             ICPConfiguration::builder()
@@ -335,7 +333,7 @@ mod tests {
         let isom = nalgebra::Isometry3::new(translation, rotation);
         let points_transformed = transform_point_cloud(&points, isom);
 
-        let res = super::f32::icp_3d(
+        let res = single_precision::icp_3d(
             points.as_slice(),
             points_transformed.as_slice(),
             ICPConfiguration::builder()
@@ -355,7 +353,7 @@ mod tests {
         let isom = nalgebra::Isometry3::new(translation, rotation);
         let points_transformed = transform_point_cloud(&points, isom);
 
-        let res = super::f32::icp_3d(
+        let res = single_precision::icp_3d(
             points.as_slice(),
             points_transformed.as_slice(),
             ICPConfiguration::builder()

--- a/crates/algorithms/src/icp/types.rs
+++ b/crates/algorithms/src/icp/types.rs
@@ -6,7 +6,7 @@ use num_traits::AsPrimitive;
 #[derive(Debug)]
 pub struct ICPSuccess<T: Scalar, R: AbstractRotation<T, N>, const N: usize> {
     /// An isometric matrix, containing the translation and rotation between the point sets.
-    /// In 2D space, its rotation component would be a [`nalgebra::UnitComplex<T>`](nalgebra::UnitComplex), in 3D space it would be a [`nalgebra::UnitQuaternion<T>`](nalgebra::UnitQuaternion).
+    /// In 2D space, its rotation component would be a [`UnitComplex`](nalgebra::UnitComplex), in 3D space it would be a [`UnitQuaternion`](nalgebra::UnitQuaternion).
     pub transform: Isometry<T, R, N>,
     /// Mean Squared Error, this is the distances between each point in `points_a` and its corresponding point in `points_b`,
     /// This can be used to determine whether the ICP converged correctly, or simply on its local minimum.

--- a/crates/algorithms/src/kd_tree/mod.rs
+++ b/crates/algorithms/src/kd_tree/mod.rs
@@ -23,7 +23,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument("Insert New Point", skip_all))]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument("Insert New Point", skip_all, level = "trace")
+    )]
     fn insert(&mut self, data: Point<T, N>, depth: usize) {
         let dimension_to_check = depth % N;
 
@@ -44,7 +47,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument("Branch Nearest Neighbour", skip_all)
+        tracing::instrument("Branch Nearest Neighbour", skip_all, level = "trace")
     )]
     fn nearest(&self, target: &Point<T, N>, depth: usize) -> Option<Point<T, N>> {
         let dimension_to_check = depth % N;
@@ -82,7 +85,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument("Traverse Branch With Function", skip_all)
+        tracing::instrument("Traverse Branch With Function", skip_all, level = "debug")
     )]
     fn traverse_branch<F: FnMut(&Point<T, N>)>(&self, func: &mut F) {
         if let Some(left) = self.left.as_ref() {
@@ -96,7 +99,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument("Traverse Branch With Mutable Function)", skip_all)
+        tracing::instrument("Traverse Branch With Mutable Function)", skip_all, level = "debug")
     )]
     fn traverse_branch_mut<F: FnMut(&mut Point<T, N>)>(&mut self, func: &mut F) {
         if let Some(left) = self.left.as_mut() {
@@ -135,7 +138,10 @@ where
     ///
     /// # Arguments
     /// * `data`: a [`Point`], to be inserted into the tree.
-    #[cfg_attr(feature = "tracing", tracing::instrument("Insert To Tree", skip_all))]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument("Insert To Tree", skip_all, level = "debug")
+    )]
     pub fn insert(&mut self, data: Point<T, N>) {
         if let Some(root) = self.root.as_mut() {
             root.insert(data, 0);
@@ -152,7 +158,7 @@ where
     /// [`None`] if the tree is empty, otherwise returns the closest [`Point`].
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument("Find Nearest Neighbour", skip_all)
+        tracing::instrument("Find Nearest Neighbour", skip_all, level = "debug")
     )]
     pub fn nearest(&self, target: &Point<T, N>) -> Option<Point<T, N>> {
         self.root.as_ref().and_then(|root| root.nearest(target, 0))
@@ -164,7 +170,7 @@ where
     /// * `func`: a closure of type [`Fn`], it's only parameter is a reference of the branch's [`Point`].
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument("Traverse Tree With Function", skip_all)
+        tracing::instrument("Traverse Tree With Function", skip_all, level = "info")
     )]
     pub fn traverse_tree<F: FnMut(&Point<T, N>)>(&self, mut func: F) {
         if let Some(root) = self.root.as_ref() {
@@ -178,7 +184,7 @@ where
     /// * func: a closure of type [`FnMut`], it's only parameter is a reference of the branch's [`Point`].
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument("Traverse Tree With Mutable Function", skip_all)
+        tracing::instrument("Traverse Tree With Mutable Function", skip_all, level = "info")
     )]
     pub fn traverse_tree_mut<F: FnMut(&mut Point<T, N>)>(&mut self, mut func: F) {
         if let Some(root) = self.root.as_mut() {
@@ -193,7 +199,7 @@ where
 {
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument("Generate Tree From Point Cloud", skip_all)
+        tracing::instrument("Generate Tree From Point Cloud", skip_all, level = "info")
     )]
     fn from(point_cloud: &[Point<T, N>]) -> Self {
         point_cloud

--- a/crates/algorithms/src/lib.rs
+++ b/crates/algorithms/src/lib.rs
@@ -11,11 +11,13 @@ extern crate alloc;
 extern crate core;
 
 #[cfg(feature = "std")]
-use std::{array, boxed::Box, collections::HashMap, fmt::Debug, iter::Sum, mem, ops, vec::Vec};
+use std::{
+    array, boxed::Box, collections::HashMap, fmt::Debug, iter::Sum, marker, mem, ops, vec::Vec,
+};
 #[cfg(not(feature = "std"))]
 use {
     alloc::{boxed::Box, collections::BTreeMap as HashMap, vec::Vec},
-    core::{array, fmt::Debug, iter::Sum, mem, ops},
+    core::{array, fmt::Debug, iter::Sum, marker, mem, ops},
 };
 
 /// An Iterative Closest Point algorithm, useful in matching Point Clouds.

--- a/crates/algorithms/src/point_in_polygon/mod.rs
+++ b/crates/algorithms/src/point_in_polygon/mod.rs
@@ -1,5 +1,5 @@
 use crate::{mem, utils::calculate_polygon_extents, Vec};
-use nalgebra::{Point, Point2, RealField, Vector2};
+use nalgebra::{Point2, RealField, Vector2};
 use num_traits::Bounded;
 
 /// Check whether a specified ray(with origin at 0) collides with another ray.
@@ -17,7 +17,7 @@ use num_traits::Bounded;
 #[inline]
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument("Does Ray Intersect Polygon", skip_all)
+    tracing::instrument("Does Ray Intersect Polygon", skip_all, level = "trace")
 )]
 pub fn does_ray_intersect<T>(
     point: &Vector2<T>,
@@ -68,7 +68,11 @@ where
 /// A usize, representing the number of intersections.
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument("Get Point's Number Of Intersections With Polygon", skip_all)
+    tracing::instrument(
+        "Get Point's Number Of Intersections With Polygon",
+        skip_all,
+        level = "debug"
+    )
 )]
 pub fn get_point_intersections_with_polygon<T>(
     point: &Point2<T>,
@@ -101,7 +105,7 @@ where
 /// A boolean value, specifying if the point is within the polygon.
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument("Is Point In Polygon", skip_all)
+    tracing::instrument("Is Point In Polygon", skip_all, level = "debug")
 )]
 pub fn is_single_point_in_polygon<T>(point: &Point2<T>, polygon: &[Point2<T>]) -> bool
 where
@@ -115,8 +119,8 @@ where
 /// But pre-calculates the polygon extents to reduce workloads for larger datasets, please profile this for you specific use-case.
 ///
 /// # Arguments
-/// * `points`: A slice of [`Point`].
-/// * `polygon`: A slice of [`Point`]s, representing the vertices.
+/// * `points`: A slice of [`Point2`].
+/// * `polygon`: A slice of [`Point2`]s, representing the vertices.
 ///
 /// # Generics:
 /// * `T`: Either an [`prim@f32`] or [`prim@f64`]
@@ -125,12 +129,9 @@ where
 /// A [`Vec`] of booleans, with the same size as `points`, containing the result for each point.
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument("Are Points In Polygon", skip_all)
+    tracing::instrument("Are Points In Polygon", skip_all, level = "info")
 )]
-pub fn are_multiple_points_in_polygon<T>(
-    points: &[Point<T, 2>],
-    polygon: &[Point<T, 2>],
-) -> Vec<bool>
+pub fn are_multiple_points_in_polygon<T>(points: &[Point2<T>], polygon: &[Point2<T>]) -> Vec<bool>
 where
     T: Bounded + Copy + RealField,
 {
@@ -160,42 +161,45 @@ macro_rules! impl_p_i_p_algorithm {
         ::paste::paste! {
             #[doc = "A " $doc "-precision implementation of a point-in-polygon algorithm."]
             pub mod [<$doc _precision>] {
+                use nalgebra::{Point2, Vector2};
+                use crate::Vec;
+
                 #[doc = "Check whether a specified ray(with origin 0) collides with another ray."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `ray`: A reference to a [`Vector2`](nalgebra::Vector2), representing a ray, whose origin is [0.0, 0.0]."]
-                #[doc = "* `vertex1`: A [`Point2`](nalgebra::Point2) representing the first vertex of the other ray."]
-                #[doc = "* `vertex2`: A [`Point2`](nalgebra::Point2) representing the second vertex of the other ray."]
+                #[doc = "* `ray`: A reference to a [`Vector2`], representing a ray, whose origin is [0.0, 0.0]."]
+                #[doc = "* `vertex1`: A [`Point2`] representing the first vertex of the other ray."]
+                #[doc = "* `vertex2`: A [`Point2`] representing the second vertex of the other ray."]
                 #[doc = ""]
                 #[doc = "# Returns"]
                 #[doc = "A `bool`, specifying whether the rays intersect"]
-                pub fn does_ray_intersect(ray: &nalgebra::Vector2<$prec>, vertex1: nalgebra::Point2<$prec>, vertex2: nalgebra::Point2<$prec>) -> bool {
+                pub fn does_ray_intersect(ray: &Vector2<$prec>, vertex1: Point2<$prec>, vertex2: Point2<$prec>) -> bool {
                     super::does_ray_intersect(ray, vertex1, vertex2)
                 }
 
                 #[doc = "Get all intersections of this point, with this polygon."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `point`: A reference to a [`Point2`](nalgebra::Point2)"]
-                #[doc = "* `polygon`: A slice of [`Point2`](nalgebra::Point2)s representing the vertices."]
+                #[doc = "* `point`: A reference to a [`Point2`]"]
+                #[doc = "* `polygon`: A slice of [`Point2`]s representing the vertices."]
                 #[doc = ""]
                 #[doc = "# Returns"]
                 #[doc = "A usize, representing the number of intersections."]
                 pub fn get_point_intersections_with_polygon(
-                        point: &nalgebra::Point2<$prec>,
-                        polygon: &[nalgebra::Point2<$prec>],
-                    ) -> crate::Vec<nalgebra::Point2<$prec>> {
+                        point: &Point2<$prec>,
+                        polygon: &[Point2<$prec>],
+                    ) -> Vec<Point2<$prec>> {
                     super::get_point_intersections_with_polygon(point, polygon)
                 }
 
                 #[doc = "Check if the provided point is within the provided polygon."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `point`: A reference to a [`Point2`](nalgebra::Point2)."]
-                #[doc = "* `polygon`: A slice of [`Point2`](nalgebra::Point2)s representing the vertices."]
+                #[doc = "* `point`: A reference to a [`Point2`]."]
+                #[doc = "* `polygon`: A slice of [`Point2`]s representing the vertices."]
                 #[doc = "# Returns"]
                 #[doc = "A boolean value, specifying if the point is within the polygon."]
-                pub fn is_single_point_in_polygon(point: &nalgebra::Point2<$prec>, polygon: &[nalgebra::Point2<$prec>]) -> bool {
+                pub fn is_single_point_in_polygon(point: &Point2<$prec>, polygon: &[Point2<$prec>]) -> bool {
                     super::is_single_point_in_polygon(point, polygon)
                 }
 
@@ -203,15 +207,15 @@ macro_rules! impl_p_i_p_algorithm {
                 #[doc = "But pre-calculates the polygon extents to reduce workloads for larger datasets, please profile this for you specific use-case."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `points`: A slice of [`Point2`](nalgebra::Point2)."]
-                #[doc = "* `polygon`: A slice of [`Point2`](nalgebra::Point2)s, representing the vertices."]
+                #[doc = "* `points`: A slice of [`Point2`]."]
+                #[doc = "* `polygon`: A slice of [`Point2`]s, representing the vertices."]
                 #[doc = ""]
                 #[doc = "# Returns"]
                 #[doc = "A [`Vec`](crate::Vec) of booleans, with the same size as `points`, containing the result for each point."]
                 pub fn are_multiple_points_in_polygon(
-                    points: &[nalgebra::Point2<$prec>],
-                    polygon: &[nalgebra::Point2<$prec>],
-                ) -> crate::Vec<bool> {
+                    points: &[Point2<$prec>],
+                    polygon: &[Point2<$prec>],
+                ) -> Vec<bool> {
                     super::are_multiple_points_in_polygon(points, polygon)
                 }
             }

--- a/crates/algorithms/src/point_in_polygon/mod.rs
+++ b/crates/algorithms/src/point_in_polygon/mod.rs
@@ -156,65 +156,63 @@ where
 
 #[cfg(feature = "pregenerated")]
 macro_rules! impl_p_i_p_algorithm {
-    ($prec:expr, $prec_str:tt) => {
+    ($prec:expr, doc $doc:tt) => {
         ::paste::paste! {
-            #[doc = "A " $prec_str "-precision implementation of a point-in-polygon algorithm."]
-            pub mod $prec {
-                use super::*;
-
+            #[doc = "A " $doc "-precision implementation of a point-in-polygon algorithm."]
+            pub mod [<$doc _precision>] {
                 #[doc = "Check whether a specified ray(with origin 0) collides with another ray."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `ray`: A reference to a [`Vector2`], representing a ray, whose origin is [0.0, 0.0]."]
-                #[doc = "* `vertex1`: A [`Point2`] representing the first vertex of the other ray."]
-                #[doc = "* `vertex2`: A [`Point2`] representing the second vertex of the other ray."]
+                #[doc = "* `ray`: A reference to a [`Vector2`](nalgebra::Vector2), representing a ray, whose origin is [0.0, 0.0]."]
+                #[doc = "* `vertex1`: A [`Point2`](nalgebra::Point2) representing the first vertex of the other ray."]
+                #[doc = "* `vertex2`: A [`Point2`](nalgebra::Point2) representing the second vertex of the other ray."]
                 #[doc = ""]
                 #[doc = "# Returns"]
                 #[doc = "A `bool`, specifying whether the rays intersect"]
-                pub fn [<does_ray_intersect_$prec>](ray: &Vector2<$prec>, vertex1: Point2<$prec>, vertex2: Point2<$prec>) -> bool {
-                    does_ray_intersect(ray, vertex1, vertex2)
+                pub fn does_ray_intersect(ray: &nalgebra::Vector2<$prec>, vertex1: nalgebra::Point2<$prec>, vertex2: nalgebra::Point2<$prec>) -> bool {
+                    super::does_ray_intersect(ray, vertex1, vertex2)
                 }
 
                 #[doc = "Get all intersections of this point, with this polygon."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `point`: A reference to a [`Point2`]"]
-                #[doc = "* `polygon`: A slice of [`Point2`]s representing the vertices."]
+                #[doc = "* `point`: A reference to a [`Point2`](nalgebra::Point2)"]
+                #[doc = "* `polygon`: A slice of [`Point2`](nalgebra::Point2)s representing the vertices."]
                 #[doc = ""]
                 #[doc = "# Returns"]
                 #[doc = "A usize, representing the number of intersections."]
-                pub fn [<get_point_intersections_with_polygon_$prec>](
-                        point: &Point2<$prec>,
-                        polygon: &[Point2<$prec>],
-                    ) -> Vec<Point2<$prec>> {
-                    get_point_intersections_with_polygon(point, polygon)
+                pub fn get_point_intersections_with_polygon(
+                        point: &nalgebra::Point2<$prec>,
+                        polygon: &[nalgebra::Point2<$prec>],
+                    ) -> crate::Vec<nalgebra::Point2<$prec>> {
+                    super::get_point_intersections_with_polygon(point, polygon)
                 }
 
                 #[doc = "Check if the provided point is within the provided polygon."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `point`: A reference to a [`Point2`]."]
-                #[doc = "* `polygon`: A slice of [`Point2`]s representing the vertices."]
+                #[doc = "* `point`: A reference to a [`Point2`](nalgebra::Point2)."]
+                #[doc = "* `polygon`: A slice of [`Point2`](nalgebra::Point2)s representing the vertices."]
                 #[doc = "# Returns"]
                 #[doc = "A boolean value, specifying if the point is within the polygon."]
-                pub fn [<is_single_point_in_polygon_$prec>](point: &Point2<$prec>, polygon: &[Point2<$prec>]) -> bool {
-                    is_single_point_in_polygon(point, polygon)
+                pub fn is_single_point_in_polygon(point: &nalgebra::Point2<$prec>, polygon: &[nalgebra::Point2<$prec>]) -> bool {
+                    super::is_single_point_in_polygon(point, polygon)
                 }
 
-                #[doc = "This function will run the [`is_single_point_in_polygon_" $prec "`] for each on of the points given, and the provided polygon,"]
+                #[doc = "This function will run the [`is_single_point_in_polygon`] for each on of the points given, and the provided polygon,"]
                 #[doc = "But pre-calculates the polygon extents to reduce workloads for larger datasets, please profile this for you specific use-case."]
                 #[doc = ""]
                 #[doc = "# Arguments"]
-                #[doc = "* `points`: A slice of [`Point`]."]
-                #[doc = "* `polygon`: A slice of [`Point`]s, representing the vertices."]
+                #[doc = "* `points`: A slice of [`Point2`](nalgebra::Point2)."]
+                #[doc = "* `polygon`: A slice of [`Point2`](nalgebra::Point2)s, representing the vertices."]
                 #[doc = ""]
                 #[doc = "# Returns"]
-                #[doc = "A [`Vec`] of booleans, with the same size as `points`, containing the result for each point."]
-                pub fn [<are_multiple_points_in_polygon_$prec>](
-                    points: &[Point2<$prec>],
-                    polygon: &[Point2<$prec>],
-                ) -> Vec<bool> {
-                    are_multiple_points_in_polygon(points, polygon)
+                #[doc = "A [`Vec`](crate::Vec) of booleans, with the same size as `points`, containing the result for each point."]
+                pub fn are_multiple_points_in_polygon(
+                    points: &[nalgebra::Point2<$prec>],
+                    polygon: &[nalgebra::Point2<$prec>],
+                ) -> crate::Vec<bool> {
+                    super::are_multiple_points_in_polygon(points, polygon)
                 }
             }
         }
@@ -222,12 +220,13 @@ macro_rules! impl_p_i_p_algorithm {
 }
 
 #[cfg(feature = "pregenerated")]
-impl_p_i_p_algorithm!(f32, single);
+impl_p_i_p_algorithm!(f32, doc single);
 #[cfg(feature = "pregenerated")]
-impl_p_i_p_algorithm!(f64, double);
+impl_p_i_p_algorithm!(f64, doc double);
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::Vec;
     use nalgebra::{Point2, Vector2};
 
@@ -236,14 +235,14 @@ mod tests {
         let point_a = Vector2::new(4.0, -3.0);
         let vertex_a1 = Point2::new(5.0, 0.0);
         let vertex_a2 = Point2::new(1.0, -4.0);
-        assert!(super::f32::does_ray_intersect_f32(
+        assert!(single_precision::does_ray_intersect(
             &point_a, vertex_a1, vertex_a2
         ));
 
         let point_b = Vector2::new(-4.0, 4.0);
         let vertex_b1 = Point2::new(0.0, 0.0);
         let vertex_b2 = Point2::new(1.0, 5.0);
-        assert!(super::f32::does_ray_intersect_f32(
+        assert!(single_precision::does_ray_intersect(
             &point_b, vertex_b1, vertex_b2
         ));
     }
@@ -265,7 +264,7 @@ mod tests {
             Point2::from([1.5, 1.5]), // Outside
         ];
 
-        let result = super::f32::are_multiple_points_in_polygon_f32(points, polygon);
+        let result = single_precision::are_multiple_points_in_polygon(points, polygon);
 
         // Expecting [true, false] since the first point is inside and the second is outside.
         assert_eq!(result, Vec::from([true, false]));
@@ -287,7 +286,7 @@ mod tests {
             Point2::from([1.5, 1.5]), // Outside
         ];
 
-        let result = super::f32::are_multiple_points_in_polygon_f32(points, polygon);
+        let result = single_precision::are_multiple_points_in_polygon(points, polygon);
 
         // Expecting [true, false] since the first point is inside and the second is outside.
         assert_eq!(result, Vec::from([true, false]));

--- a/crates/algorithms/src/types/mod.rs
+++ b/crates/algorithms/src/types/mod.rs
@@ -38,6 +38,10 @@ where
 {
     type RotType = UnitComplex<T>;
 
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument("Update 2D Transform Using SVD", skip_all, level = "debug")
+    )]
     fn update_transform(
         old_transform: &Isometry<T, Self::RotType, 2>,
         mean_a: Point<T, 2>,
@@ -59,6 +63,10 @@ where
 {
     type RotType = UnitQuaternion<T>;
 
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument("Update 3D Transform Using SVD", skip_all, level = "debug")
+    )]
     fn update_transform(
         old_transform: &Isometry<T, Self::RotType, 3>,
         mean_a: Point<T, 3>,

--- a/crates/algorithms/src/types/mod.rs
+++ b/crates/algorithms/src/types/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ops::RangeInclusive, utils::verify_rotation_matrix_determinant};
+use crate::{marker::PhantomData, ops::RangeInclusive, utils::verify_rotation_matrix_determinant};
 use nalgebra::{
     AbstractRotation, ArrayStorage, Const, Isometry, Matrix, Point, RealField, UnitComplex,
     UnitQuaternion,
@@ -9,59 +9,68 @@ use nalgebra::{
 pub(crate) type SameSizeMat<T, const N: usize> =
     Matrix<T, Const<N>, Const<N>, ArrayStorage<T, N, N>>;
 
+/// This struct allows us to write functions in a generic way for both 2D and 3D dimensions, by implementing
+pub struct IsometryAbstractor<T: RealField, const N: usize> {
+    _precision: PhantomData<T>,
+}
+
 /// This trait acts as an abstraction for the process of creating an [`Isometry`] matrix from a NxN SVD,
 /// without having to constrain every function by a million traits.
-pub trait SVDIsometry<T, const N: usize>: AbstractRotation<T, N>
-where
-    T: Default + RealField,
-{
+pub trait AbstractIsometry<T: RealField, const N: usize> {
+    /// This type is a placeholder for either [`UnitComplex`] or [`UnitQuaternion`] depending on number of dimensions.
+    type RotType: AbstractRotation<T, N> + Copy;
+
     /// This function receives the old transform, the centeroids of both point clouds, and the covariance rotation mat
     /// It then performs [`SVD`](nalgebra::SVD) on the covariance matrix, and uses the resulting matrics
     /// and the translation between the two points to construct a new transform.
     /// This transform is multiplied by the old transform, and the result is returned
     fn update_transform(
-        old_transform: &Isometry<T, Self, N>,
+        old_transform: &Isometry<T, Self::RotType, N>,
         mean_a: Point<T, N>,
         mean_b: Point<T, N>,
         rot_mat: &SameSizeMat<T, N>,
-    ) -> Isometry<T, Self, N>;
+    ) -> Isometry<T, Self::RotType, N>;
 }
 
-impl<T> SVDIsometry<T, 2> for UnitComplex<T>
+impl<T> AbstractIsometry<T, 2> for IsometryAbstractor<T, 2>
 where
-    T: Copy + Default + RealField,
+    T: Copy + RealField,
 {
-    #[inline]
+    type RotType = UnitComplex<T>;
+
     fn update_transform(
-        old_transform: &Isometry<T, Self, 2>,
+        old_transform: &Isometry<T, Self::RotType, 2>,
         mean_a: Point<T, 2>,
         mean_b: Point<T, 2>,
         rot_mat: &SameSizeMat<T, 2>,
-    ) -> Isometry<T, Self, 2> {
+    ) -> Isometry<T, Self::RotType, 2> {
         let svd = rot_mat.svd(true, true);
         let rotation = verify_rotation_matrix_determinant(svd.u.unwrap(), svd.v_t.unwrap());
         let translation = mean_b.coords - (rotation * mean_a.coords);
 
-        Isometry::from_parts(translation.into(), Self::from_matrix(&rotation)) * old_transform
+        Isometry::from_parts(translation.into(), Self::RotType::from_matrix(&rotation))
+            * old_transform
     }
 }
 
-impl<T> SVDIsometry<T, 3> for UnitQuaternion<T>
+impl<T> AbstractIsometry<T, 3> for IsometryAbstractor<T, 3>
 where
-    T: Copy + Default + RealField,
+    T: Copy + RealField,
 {
-    #[inline]
+    type RotType = UnitQuaternion<T>;
+
     fn update_transform(
-        old_transform: &Isometry<T, Self, 3>,
+        old_transform: &Isometry<T, Self::RotType, 3>,
         mean_a: Point<T, 3>,
         mean_b: Point<T, 3>,
         rot_mat: &SameSizeMat<T, 3>,
-    ) -> Isometry<T, Self, 3> {
+    ) -> Isometry<T, Self::RotType, 3> {
         let svd = rot_mat.svd(true, true);
         let rotation = verify_rotation_matrix_determinant(svd.u.unwrap(), svd.v_t.unwrap());
         let translation = mean_b.coords - (rotation * mean_a.coords);
 
-        Isometry::from_parts(translation.into(), Self::from_matrix(&rotation)) * old_transform
+        Isometry::from_parts(translation.into(), Self::RotType::from_matrix(&rotation))
+            * old_transform
     }
 }
 

--- a/crates/algorithms/src/types/mod.rs
+++ b/crates/algorithms/src/types/mod.rs
@@ -5,7 +5,7 @@ use nalgebra::{
 };
 
 /// A shorthand way of specifying a symmetrical [`Matrix`](Matrix) of `N` size.
-/// Kind of similiar to nalgebra's [`nalgebra::SquareMatrix`] but simpler for our usecase
+/// Kind of similiar to nalgebra's [`SquareMatrix`](nalgebra::SquareMatrix) but simpler for our usecase
 pub(crate) type SameSizeMat<T, const N: usize> =
     Matrix<T, Const<N>, Const<N>, ArrayStorage<T, N, N>>;
 

--- a/crates/algorithms/src/utils/mod.rs
+++ b/crates/algorithms/src/utils/mod.rs
@@ -9,6 +9,10 @@ use num_traits::{Bounded, NumOps};
 /// Various utility functions regarding point clouds of 2 or 3 dimensions.
 pub mod point_cloud;
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument("Calculate Distance Squared", skip_all, level = "trace")
+)]
 pub(crate) fn distance_squared<T, const N: usize>(point_a: &Point<T, N>, point_b: &Point<T, N>) -> T
 where
     T: Copy + Default + NumOps + Scalar,
@@ -30,13 +34,13 @@ where
 /// * `N`: a constant generic of type [`usize`].
 ///
 /// # Arguments
-/// * `polygon`: a slice of [`Point<T, N>`].
+/// * `polygon`: a slice of [`Point`].
 ///
 /// # Returns
 /// See [`PolygonExtents`]
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument("Calculate Polygon Extents", skip_all)
+    tracing::instrument("Calculate Polygon Extents", skip_all, level = "info")
 )]
 pub fn calculate_polygon_extents<T, const N: usize>(polygon: &[Point<T, N>]) -> PolygonExtents<T, N>
 where
@@ -57,6 +61,10 @@ where
     extents_accumulator
 }
 
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument("Verify Matrix Determinant", skip_all, level = "info")
+)]
 pub(crate) fn verify_rotation_matrix_determinant<T, const N: usize>(
     mut u: SameSizeMat<T, N>,
     v_t: SameSizeMat<T, N>,

--- a/crates/algorithms/src/utils/point_cloud.rs
+++ b/crates/algorithms/src/utils/point_cloud.rs
@@ -85,17 +85,21 @@ where
 ///
 /// # Arguments
 /// * `num_points`: a [`usize`], specifying the amount of points to generate
-/// * `range`: a [`crate::ops::RangeInclusive<T>`] specifying the normal distribution of points.
+/// * `range`: a [`crate::ops::RangeInclusive`] specifying the normal distribution of points.
 ///
 /// # Generics
 /// * `T`: Either an [`f32`] or [`f64`].
 /// * `N`: A const usize, representing the number of dimensions to use.
 ///
 /// # Returns
-/// A [`Vec`] of [`Point<f32, N>`] representing the point cloud.
+/// A [`Vec`] of [`Point`] representing the point cloud.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument("Generate Randomized Point Cloud", skip_all, level = "debug")
+)]
 pub fn generate_point_cloud<T, const N: usize>(
     num_points: usize,
-    range: crate::ops::RangeInclusive<T>,
+    ranges: [crate::ops::RangeInclusive<T>; N],
 ) -> Vec<Point<T, N>>
 where
     T: PartialOrd + rand::distributions::uniform::SampleUniform + Scalar,
@@ -104,7 +108,7 @@ where
     let mut rng = rand::rngs::SmallRng::seed_from_u64(3765665954583626552);
 
     (0..num_points)
-        .map(|_| nalgebra::Point::from(array::from_fn(|_| rng.gen_range(range.clone()))))
+        .map(|_| nalgebra::Point::from(array::from_fn(|idx| rng.gen_range(ranges[idx].clone()))))
         .collect()
 } // Just calls a different function a number of times, no specific test needed
 
@@ -112,8 +116,8 @@ where
 /// This function does not mutate the original point cloud.
 ///
 /// # Arguments
-/// * `source_points`: a slice of [`Point<T, N>`], representing the point cloud
-/// * `isometry_matrix`: a transform that implements [`AbstractRotation<T, N>`], to use for the transformation.
+/// * `source_points`: a slice of [`Point`], representing the point cloud
+/// * `isometry_matrix`: a transform that implements [`AbstractRotation`], to use for the transformation.
 ///
 /// # Generics
 /// * `T`: Either an [`f32`] or [`f64`].
@@ -121,7 +125,7 @@ where
 /// * `R`: An [`AbstractRotation`] for `T` and `N`.
 ///
 /// # Returns
-/// A [`Vec`] of [`Point<f32, N>`] containing the transformed point cloud.
+/// A [`Vec`] of [`Point`] containing the transformed point cloud.
 #[inline]
 #[cfg_attr(
     feature = "tracing",
@@ -144,7 +148,7 @@ where
 /// Downsample a points cloud, returning a new point cloud, with all points within each voxel combined into their mean.
 ///
 /// # Arguments
-/// * `points`: a slice of [`Point<T, N>`], representing the point cloud.
+/// * `points`: a slice of [`Point`], representing the point cloud.
 /// * `voxel_size`: a floating point number, specifying the size for each voxel, all points inside that voxel will be downsampled to their centeroid..
 ///
 /// # Generics
@@ -152,7 +156,7 @@ where
 /// * `N`: A const usize, representing the number of dimensions in the points.
 ///
 /// # Returns
-/// A [`Vec`] of [`Point<f32, N>`] representing the downsampled point cloud.
+/// A [`Vec`] of [`Point`] representing the downsampled point cloud.
 ///
 /// # Warnings
 /// * Point cloud order is *never* guaranteed.


### PR DESCRIPTION
This will allow both users and our `suites` crate to use this algorithm in freeform mode(for n-dimensional algorithms).
Another important change is the usage of an abstraction crate and struct combination, which allows us to select a Rotation based on dimensions, rather than having to specify it.

The bottom line is that users now only have to specify the floating point precision, and number of dimensions, making the ICP a lot easier to use in its free form.

Also added tracing levels to instrumentation, and ensured every crate function is instrumented.